### PR TITLE
画像一覧画面の追加とページ遷移の実装

### DIFF
--- a/lib/image_list_page.dart
+++ b/lib/image_list_page.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:sample_transition_animation/router.dart';
+
+class ImageListPage extends StatelessWidget {
+  const ImageListPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios),
+          onPressed: () {
+            context.goNamed(AppRoute.home.name);
+          },
+        ),
+        title: const Text(
+          "ImageListPage",
+        ),
+      ),
+      body: const SafeArea(
+        child: Center(
+          child: Text(
+            "ImageListPage",
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,6 +68,10 @@ class _MyHomePageState extends State<MyHomePage> {
               AppRoute.wipeTrainsitionPage.name,
               "WipeTransitionPage",
             ),
+            _buildGoToPageButton(
+              AppRoute.imageListPage.name,
+              "ImageListPage",
+            ),
           ],
         ),
       ),

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:sample_transition_animation/image_list_page.dart';
 import 'package:sample_transition_animation/main.dart';
 
 enum AppRoute {
@@ -34,6 +35,10 @@ enum AppRoute {
   wipeTrainsitionPage(
     path: '/wipeTransitionPage',
     name: 'wipeTransitionPage',
+  ),
+  imageListPage(
+    path: '/imageListPage',
+    name: 'imageListPage',
   ),
   page1(
     path: '/page1',
@@ -281,6 +286,13 @@ final goRouter = GoRouter(
         },
       ),
     ),
+    GoRoute(
+      path: AppRoute.imageListPage.path,
+      name: AppRoute.imageListPage.name,
+      builder: (context, state) {
+        return const ImageListPage();
+      },
+    )
   ],
 );
 


### PR DESCRIPTION
# 概要
#1 [画像一覧と画像詳細のページ遷移を実装する](https://github.com/AppDeveloperMLLB/sample_transition_animation/issues/1) の分割タスクである「画像一覧画面の追加とページ遷移の実装」の実装

# 対応内容
・画像一覧ページを追加（詳細の実装はまだ）
・画像一覧ページへの遷移ルートを追加
・ホーム画面から画像一覧ページへ遷移できるようにボタンを追加

# テスト内容
・ホーム画面から画像一覧ページへ遷移できること
・画像一覧ページからホーム画面へ遷移できること

![Issue1_1_1](https://user-images.githubusercontent.com/84686926/220554266-e2579a7e-90d1-4156-a561-0415fa2aa598.gif)



# レビューして欲しいところ
<!-- 実装、設計の相談、ここはこうしたけどこの点で問題はないだろうか、このあたりいじってるけど特に悪いことはないか -->
・特になし

# 備考
・特になし


