### PR TITLE
Feat/add image detail page

### DIFF
--- a/lib/image_detail_page.dart
+++ b/lib/image_detail_page.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class ImageDetailPage extends StatelessWidget {
+  final int index;
+  const ImageDetailPage({
+    super.key,
+    required this.index,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Image Detail Page"),
+      ),
+      body: SafeArea(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: GestureDetector(
+              onVerticalDragEnd: (details) {
+                if (details.primaryVelocity! > 0) return;
+                context.pop();
+              },
+              child: Container(
+                color: Colors.grey.withOpacity(0.3),
+                child: Center(
+                  child: Text("$index"),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/image_detail_page.dart
+++ b/lib/image_detail_page.dart
@@ -19,9 +19,10 @@ class ImageDetailPage extends StatelessWidget {
           child: Padding(
             padding: const EdgeInsets.all(16.0),
             child: GestureDetector(
-              onVerticalDragEnd: (details) {
-                if (details.primaryVelocity! > 0) return;
-                context.pop();
+              onVerticalDragUpdate: (details) {
+                if (details.delta.dy > 0) {
+                  context.pop();
+                }
               },
               child: Container(
                 color: Colors.grey.withOpacity(0.3),

--- a/lib/image_list_page.dart
+++ b/lib/image_list_page.dart
@@ -31,7 +31,7 @@ class ImageListPage extends StatelessWidget {
             padding: const EdgeInsets.all(8),
             itemBuilder: (context, index) {
               return Item(
-                text: "$index",
+                index: index,
               );
             },
             shrinkWrap: true,
@@ -43,20 +43,22 @@ class ImageListPage extends StatelessWidget {
 }
 
 class Item extends StatelessWidget {
-  final String text;
-  const Item({super.key, required this.text});
+  final int index;
+  const Item({super.key, required this.index});
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        // TODO: implements to go to image detail page.
-        print("on tap");
+        context.goNamed(
+          AppRoute.imageDetailPage.name,
+          extra: index,
+        );
       },
       child: Container(
         color: Colors.grey.withOpacity(0.3),
         child: Center(
-          child: Text(text),
+          child: Text("$index"),
         ),
       ),
     );

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:sample_transition_animation/image_detail_page.dart';
 import 'package:sample_transition_animation/image_list_page.dart';
 import 'package:sample_transition_animation/main.dart';
 
@@ -39,6 +40,10 @@ enum AppRoute {
   imageListPage(
     path: '/imageListPage',
     name: 'imageListPage',
+  ),
+  imageDetailPage(
+    path: '/imageListPage/imageDetailPage',
+    name: 'imageDetailPage',
   ),
   page1(
     path: '/page1',
@@ -292,7 +297,19 @@ final goRouter = GoRouter(
       builder: (context, state) {
         return const ImageListPage();
       },
-    )
+      routes: [
+        GoRoute(
+          path: "imageDetailPage",
+          name: AppRoute.imageDetailPage.name,
+          builder: (context, state) {
+            final index = state.extra as int;
+            return ImageDetailPage(
+              index: index,
+            );
+          },
+        ),
+      ],
+    ),
   ],
 );
 


### PR DESCRIPTION
# 概要
<!-- Issue番号（#1）などリンクを記載する -->
#1 の画像詳細画面の追加とページ遷移の実装

# 対応内容
<!-- やった内容を箇条書きで記載する -->
・画像詳細ページの追加
・画像一覧から画像詳細ページへの遷移を追加

![Issue1_3](https://user-images.githubusercontent.com/84686926/221068148-c1ad8e7d-b97c-4651-a512-f699822b1cbd.gif)



# テスト内容
<!-- テスト手順と期待する動作を書く -->
・画像一覧ページで個別の画像をタップ
　- [ ] 画像詳細ページへ遷移すること
　- [ ] 画像一覧ページでタップした画像が表示されていること

# レビューして欲しいところ
<!-- 実装、設計の相談、ここはこうしたけどこの点で問題はないだろうか、このあたりいじってるけど特に悪いことはないか -->
・画像詳細から画像を下にスワイプした場合にのみ、画像一覧画面に戻りたいが、上にスワイプした場合も前の画面に戻ってしまう。何かいい方法はないか？

# 備考
特になし

